### PR TITLE
Remove client_id and client_secret string

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ To write an app using the SDK
 
     moncash.configure({
         'mode': 'sandbox', //sandbox or live
-        'client_id': 'BBWKjlBLKMYqRNQ6sYvFo64FtaRLRR5BdHBBSmha49TM',
-        'client_secret': 'BO422dn3gQLgDbuwqTjzrFgFtaRLRR5BdHBBSmha49TM'
+        'client_id': '<REPLACE WITH YOUR CLIENT ID>',
+        'client_secret': '<REPLACE WITH YOUR CLIENT SECRET>'
     });
 ```
 


### PR DESCRIPTION
Even it is a documentation, it is always important to remind people that they should not put secret in github document.